### PR TITLE
fix overrides for non vmware hosts

### DIFF
--- a/app/overrides/hosts/add_tab_to_host_overview.rb
+++ b/app/overrides/hosts/add_tab_to_host_overview.rb
@@ -1,21 +1,11 @@
-tab = "<%  if @host.provider == 'VMware' %>
-        <li><a href='#snapshots' data-toggle='tab'><%= _('Snapshots') %></a></li>
-       <% end %>"
-
-tab_content = "<div id='snapshots' class='tab-pane'
-                data-ajax-url='<%= host_snapshots_path(host_id: @host)%>'
-                data-on-complete='onContentLoad'>
-  <%= spinner(_('Loading Parameters information ...')) %>
-</div>"
-
 # Add a Snapshots tab in the view of a host
 Deface::Override.new(virtual_path: 'hosts/show',
                      name: 'add_host_snapshot_tab',
                      insert_bottom: 'ul',
-                     text: tab)
+                     partial: 'foreman_snapshot_management/hosts/snapshots_tab')
 
 # Load content of Snapshots tab
 Deface::Override.new(virtual_path: 'hosts/show',
                      name: 'add_host_snapshots_tab_content',
                      insert_bottom: 'div#myTabContent',
-                     text: tab_content)
+                     partial: 'foreman_snapshot_management/hosts/snapshots_tab_content')

--- a/app/views/foreman_snapshot_management/hosts/_snapshots_tab.html.erb
+++ b/app/views/foreman_snapshot_management/hosts/_snapshots_tab.html.erb
@@ -1,0 +1,3 @@
+<% if @host.provider == 'VMware' %>
+  <li><a href='#snapshots' data-toggle='tab'><%= _('Snapshots') %></a></li>
+<% end %>

--- a/app/views/foreman_snapshot_management/hosts/_snapshots_tab_content.html.erb
+++ b/app/views/foreman_snapshot_management/hosts/_snapshots_tab_content.html.erb
@@ -1,0 +1,7 @@
+<% if @host.provider == 'VMware' %>
+<div id='snapshots' class='tab-pane'
+  data-ajax-url='<%= host_snapshots_path(host_id: @host)%>'
+  data-on-complete='onContentLoad'>
+  <%= spinner(_('Loading Parameters information ...')) %>
+</div>
+<% end %>


### PR DESCRIPTION
This fixes

```
13:42:09 rails.1   | 2017-09-01T13:42:09 9a4d0409 [app] [F]
13:42:09 rails.1   |  | NoMethodError (undefined method `get_snapshots' for nil:NilClass):
13:42:09 rails.1   |  |   /Users/f0218175/foremandev/foreman_snapshot_management/app/models/foreman_snapshot_management/snapshot.rb:20:in `all_for_host'
13:42:09 rails.1   |  |   /Users/f0218175/foremandev/foreman_snapshot_management/app/controllers/foreman_snapshot_management/snapshots_controller.rb:110:in `enumerate_snapshots'
13:42:09 rails.1   |  |   app/controllers/concerns/application_shared.rb:15:in `set_timezone'
13:42:09 rails.1   |  |   app/models/concerns/foreman/thread_session.rb:32:in `clear_thread'
13:42:09 rails.1   |  |   app/controllers/concerns/foreman/controller/topbar_sweeper.rb:12:in `set_topbar_sweeper_controller'
13:42:09 rails.1   |  |   lib/middleware/catch_json_parse_errors.rb:8:in `call'
13:42:09 rails.1   |  |   lib/middleware/session_safe_logging.rb:17:in `call'
13:42:09 rails.1   |  |   lib/middleware/tagged_logging.rb:18:in `call'
13:42:09 rails.1   |  |
13:42:09 rails.1   |  |
```

The tab content was included for every kind of host and just hidden in the UI because the tab button was correctly filtered. This still causes the ajax to be executed by the browser. This leads to an error in the logs because hosts not on VMWare (e.g. bare metal) do have any snapshots.
This commit also moves the overrides to partials.