### PR TITLE
fix permission definition

### DIFF
--- a/app/overrides/hosts/add_tab_to_host_overview.rb
+++ b/app/overrides/hosts/add_tab_to_host_overview.rb
@@ -1,21 +1,11 @@
-tab = "<%  if @host.provider == 'VMware' %>
-        <li><a href='#snapshots' data-toggle='tab'><%= _('Snapshots') %></a></li>
-       <% end %>"
-
-tab_content = "<div id='snapshots' class='tab-pane'
-                data-ajax-url='<%= host_snapshots_path(host_id: @host)%>'
-                data-on-complete='onContentLoad'>
-  <%= spinner(_('Loading Parameters information ...')) %>
-</div>"
-
 # Add a Snapshots tab in the view of a host
 Deface::Override.new(virtual_path: 'hosts/show',
                      name: 'add_host_snapshot_tab',
                      insert_bottom: 'ul',
-                     text: tab)
+                     partial: 'foreman_snapshot_management/hosts/snapshots_tab')
 
 # Load content of Snapshots tab
 Deface::Override.new(virtual_path: 'hosts/show',
                      name: 'add_host_snapshots_tab_content',
                      insert_bottom: 'div#myTabContent',
-                     text: tab_content)
+                     partial: 'foreman_snapshot_management/hosts/snapshots_tab_content')

--- a/app/views/foreman_snapshot_management/hosts/_snapshots_tab.html.erb
+++ b/app/views/foreman_snapshot_management/hosts/_snapshots_tab.html.erb
@@ -1,0 +1,3 @@
+<% if @host.provider == 'VMware' %>
+  <li><a href='#snapshots' data-toggle='tab'><%= _('Snapshots') %></a></li>
+<% end %>

--- a/app/views/foreman_snapshot_management/hosts/_snapshots_tab_content.html.erb
+++ b/app/views/foreman_snapshot_management/hosts/_snapshots_tab_content.html.erb
@@ -1,0 +1,7 @@
+<% if @host.provider == 'VMware' %>
+<div id='snapshots' class='tab-pane'
+  data-ajax-url='<%= host_snapshots_path(host_id: @host)%>'
+  data-on-complete='onContentLoad'>
+  <%= spinner(_('Loading Parameters information ...')) %>
+</div>
+<% end %>

--- a/app/views/foreman_snapshot_management/snapshots/_index.html.erb
+++ b/app/views/foreman_snapshot_management/snapshots/_index.html.erb
@@ -8,24 +8,34 @@
   </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>
-        <%= f.text_field :name, class: 'form-control' %>
-      </td>
-      <td>
-        <%= f.text_field :description, class: 'form-control' %>
-      </td>
-      <td>
-        <%= f.submit _('Create'), class: 'btn btn-success' %>
-      </td>
-    </tr>
+    <% if authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :create) %>
+      <tr>
+        <td>
+          <%= f.text_field :name, class: 'form-control' %>
+        </td>
+        <td>
+          <%= f.text_field :description, class: 'form-control' %>
+        </td>
+        <td>
+          <%= f.submit _('Create'), class: 'btn btn-success' %>
+        </td>
+      </tr>
+    <% end %>
   <% @snapshots.each do |ref, snap| %>
       <tr>
         <td>
-          <%= edit_textfield snap, :name %>
+          <% if authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :edit) %>
+            <%= edit_textfield snap, :name %>
+          <% else %>
+            <%= snap.name %>
+          <% end %>
         </td>
         <td>
-          <%= edit_textarea snap, :description %>
+          <% if authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :edit) %>
+            <%= edit_textarea snap, :description %>
+          <% else %>
+            <%= snap.description %>
+          <% end %>
         </td>
         <td>
           <%= action_buttons(

--- a/lib/foreman_snapshot_management/engine.rb
+++ b/lib/foreman_snapshot_management/engine.rb
@@ -15,14 +15,36 @@ module ForemanSnapshotManagement
 
         # Add permissions
         security_block :foreman_snapshot_management do
-          permission :view_foreman_snapshot_management, :'foreman_snapshot_management/hosts' => [:new_action]
-          permission :view_foreman_snapshot_management, :'foreman_snapshot_management/virtualmachines' => [:index]
-          permission :view_foreman_snapshot_management, :'foreman_snapshot_management/createsnapshot' => [:index]
-          permission :view_foreman_snapshot_management, :'foreman_snapshot_management/createsnapshot' => [:createSnapshot]
+          permission :view_snapshots, {
+            :'foreman_snapshot_management/snapshots' => [:index]
+          }, :resource_type => 'Host'
+
+          permission :create_snapshots, {
+            :'foreman_snapshot_management/snapshots' => [:create]
+          }, :resource_type => 'Host'
+
+          permission :edit_snapshots, {
+            :'foreman_snapshot_management/snapshots' => [:update]
+          }, :resource_type => 'Host'
+
+          permission :destroy_snapshots, {
+            :'foreman_snapshot_management/snapshots' => [:destroy]
+          }, :resource_type => 'Host'
+
+          permission :revert_snapshots, {
+            :'foreman_snapshot_management/snapshots' => [:revert]
+          }, :resource_type => 'Host'
         end
 
-        # Add a new role called 'ForemanSnapshotManagement' if it doesn't exist
-        role 'ForemanSnapshotManagement', [:view_foreman_snapshot_management]
+        # Adds roles if they do not exist
+        role 'Snapshot Viewer', [:view_snapshots]
+        role 'Snapshot Manager', [
+          :view_snapshots,
+          :create_snapshots,
+          :edit_snapshots,
+          :destroy_snapshots,
+          :revert_snapshots
+        ]
       end
     end
 


### PR DESCRIPTION
This improved the definition of the plugin's permission and makes use of the new permissions in the UI.

A user with just view_snapshots permission would only see this:
![image](https://user-images.githubusercontent.com/4107560/30022569-28cd84f8-916c-11e7-9f73-193ebbdc8cc5.png)


This needs https://github.com/ATIX-AG/foreman_snapshot_management/pull/3.