### PR TITLE
hide snapshot overrides without view permissions

### DIFF
--- a/app/controllers/foreman_snapshot_management/snapshots_controller.rb
+++ b/app/controllers/foreman_snapshot_management/snapshots_controller.rb
@@ -1,6 +1,7 @@
 module ForemanSnapshotManagement
   class SnapshotsController < ApplicationController
     before_action :find_host
+    before_action :check_snapshot_capability
     before_action :enumerate_snapshots, only: [:index]
     before_action :find_snapshot, only: %i[destroy revert update]
     helper_method :xeditable?
@@ -103,6 +104,10 @@ module ForemanSnapshotManagement
       @host = Host.find_by! name: params['host_id']
     rescue => e
       process_ajax_error e, 'Host not found!'
+    end
+
+    def check_snapshot_capability
+      not_found unless @host.compute_resource && @host.compute_resource.capabilities.include?(:snapshots)
     end
 
     def enumerate_snapshots

--- a/app/models/foreman_snapshot_management/vmware_extensions.rb
+++ b/app/models/foreman_snapshot_management/vmware_extensions.rb
@@ -1,6 +1,9 @@
 module ForemanSnapshotManagement
   module VmwareExtensions
-    extend ActiveSupport::Concern
+    # Extend VMWare's capabilities with snapshots.
+    def capabilities
+      super + [:snapshots]
+    end
 
     # Create a Snapshot.
     #

--- a/app/views/foreman_snapshot_management/hosts/_snapshots_tab.html.erb
+++ b/app/views/foreman_snapshot_management/hosts/_snapshots_tab.html.erb
@@ -1,3 +1,3 @@
-<% if @host.provider == 'VMware' %>
+<% if @host.compute_resource && @host.compute_resource.capabilities.include?(:snapshots) && authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :index) %>
   <li><a href='#snapshots' data-toggle='tab'><%= _('Snapshots') %></a></li>
 <% end %>

--- a/app/views/foreman_snapshot_management/hosts/_snapshots_tab_content.html.erb
+++ b/app/views/foreman_snapshot_management/hosts/_snapshots_tab_content.html.erb
@@ -1,4 +1,4 @@
-<% if @host.provider == 'VMware' %>
+<% if @host.compute_resource && @host.compute_resource.capabilities.include?(:snapshots) && authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :index) %>
 <div id='snapshots' class='tab-pane'
   data-ajax-url='<%= host_snapshots_path(host_id: @host)%>'
   data-on-complete='onContentLoad'>

--- a/lib/foreman_snapshot_management/engine.rb
+++ b/lib/foreman_snapshot_management/engine.rb
@@ -67,7 +67,7 @@ module ForemanSnapshotManagement
     # Include concerns in this config.to_prepare block
     config.to_prepare do
       begin
-        ::Foreman::Model::Vmware.send(:include, ForemanSnapshotManagement::VmwareExtensions)
+        ::Foreman::Model::Vmware.send(:prepend, ForemanSnapshotManagement::VmwareExtensions)
       rescue => e
         Rails.logger.warn "ForemanSnapshotManagement: skipping engine hook (#{e})"
       end


### PR DESCRIPTION
This is a follow up for https://github.com/ATIX-AG/foreman_snapshot_management/pull/4. I forgot to include these changes into the latest commit.