### PR TITLE
support granular permissions

### DIFF
--- a/app/controllers/foreman_snapshot_management/snapshots_controller.rb
+++ b/app/controllers/foreman_snapshot_management/snapshots_controller.rb
@@ -79,23 +79,10 @@ module ForemanSnapshotManagement
         not_found
         return false
       end
-      @host = Host.authorized(host_permission).friendly.find(host_id)
+      @host = Host.authorized("#{action_permission}_snapshots".to_sym, Host).friendly.find(host_id)
       unless @host
         not_found
         return(false)
-      end
-    end
-
-    def host_permission
-      case action_permission.to_s
-      when 'create', 'destroy'
-        'edit'
-      when 'edit', 'view'
-        'view'
-      when 'revert'
-        'revert'
-      else
-        raise ::Foreman::Exception.new(N_('unknown host permission for %s'), "#{params[:controller]}##{action_permission}")
       end
     end
 

--- a/app/views/foreman_snapshot_management/hosts/_snapshots_tab.html.erb
+++ b/app/views/foreman_snapshot_management/hosts/_snapshots_tab.html.erb
@@ -1,3 +1,3 @@
-<% if @host.compute_resource && @host.compute_resource.capabilities.include?(:snapshots) && authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :index) %>
+<% if @host.compute_resource && @host.compute_resource.capabilities.include?(:snapshots) && authorized_for(:auth_object => @host, :permission => :view_snapshots) %>
   <li><a href='#snapshots' data-toggle='tab'><%= _('Snapshots') %></a></li>
 <% end %>

--- a/app/views/foreman_snapshot_management/hosts/_snapshots_tab_content.html.erb
+++ b/app/views/foreman_snapshot_management/hosts/_snapshots_tab_content.html.erb
@@ -1,4 +1,4 @@
-<% if @host.compute_resource && @host.compute_resource.capabilities.include?(:snapshots) && authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :index) %>
+<% if @host.compute_resource && @host.compute_resource.capabilities.include?(:snapshots) && authorized_for(:auth_object => @host, :permission => :view_snapshots) %>
 <div id='snapshots' class='tab-pane'
   data-ajax-url='<%= host_snapshots_path(host_id: @host)%>'
   data-on-complete='onContentLoad'>

--- a/app/views/foreman_snapshot_management/snapshots/_index.html.erb
+++ b/app/views/foreman_snapshot_management/snapshots/_index.html.erb
@@ -8,7 +8,7 @@
   </tr>
   </thead>
   <tbody>
-    <% if authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :create) %>
+    <% if authorized_for(:auth_object => @host, :permission => :create_snapshots) %>
       <tr>
         <td>
           <%= f.text_field :name, class: 'form-control' %>
@@ -24,7 +24,7 @@
   <% @snapshots.each do |snapshot| %>
       <tr>
         <td>
-          <% if authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :edit) %>
+          <% if authorized_for(:auth_object => @host, :permission => :edit_snapshots) %>
             <%= edit_textfield snapshot, :name %>
           <% else %>
             <%= snapshot.name %>
@@ -32,7 +32,7 @@
           <br /><%= snapshot.formatted_create_time() %>
         </td>
         <td>
-          <% if authorized_for(:controller => 'foreman_snapshot_management/snapshots', :action => :edit) %>
+          <% if authorized_for(:auth_object => @host, :permission => :edit_snapshots) %>
             <%= edit_textarea snapshot, :description %>
           <% else %>
             <%= snapshot.description %>
@@ -40,8 +40,8 @@
         </td>
         <td>
           <%= action_buttons(
-            display_link_if_authorized(_('Rollback'), hash_for_revert_host_snapshot_path(host_id: @host, id: snapshot.id), method: :put, class: 'btn btn-primary', data: {confirm: _("Are you sure to revert this Snapshot?")}),
-            display_delete_if_authorized(hash_for_host_snapshot_path(host_id: @host, id: snapshot.id), data: {confirm: _("Are you sure to delete this Snapshot?")}),
+            display_link_if_authorized(_('Rollback'), hash_for_revert_host_snapshot_path(host_id: @host, id: snapshot.id).merge(:auth_object => @host, :permission => :revert_snapshots), method: :put, class: 'btn btn-primary', data: {confirm: _("Are you sure to revert this Snapshot?")}),
+            display_delete_if_authorized(hash_for_host_snapshot_path(host_id: @host, id: snapshot.id).merge(:auth_object => @host, :permission => :delete_snapshots), data: {confirm: _("Are you sure to delete this Snapshot?")}),
           ) %>
         </td>
       </tr>


### PR DESCRIPTION
This commits changes the permission handling to support permission filters.

If a role has a filter `view_snaphots -> name ~ abc`, the user will only see snapshots for Hosts where the name includes `abc`.