### PR TITLE
remove superfluous routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   constraints(host_id: %r{[^\/]+}) do
     resources :hosts, only: [] do
-      resources :snapshots, module: 'foreman_snapshot_management' do
+      resources :snapshots, module: 'foreman_snapshot_management', only: [:index, :create, :destroy, :update] do
         member do
           put :revert
         end


### PR DESCRIPTION
Rails by default creates more rules, e.g. for a `new` action. These actions are not defined in the controller. This causes core tests to fail.

To reproduce, you can run this test from the foreman directory:

```sh
bundle exec bin/rake test TEST="test/unit/foreman/access_permissions_test.rb"
```