### PR TITLE
Add create snapshots for multiple hosts (foreman-1.16)

### DIFF
--- a/app/helpers/concerns/foreman_snapshot_management/hosts_helper_extension.rb
+++ b/app/helpers/concerns/foreman_snapshot_management/hosts_helper_extension.rb
@@ -1,0 +1,13 @@
+module ForemanSnapshotManagement
+  module HostsHelperExtension
+    extend ActiveSupport::Concern
+
+    included do
+      alias_method_chain :multiple_actions, :snapshot_management
+    end
+
+    def multiple_actions_with_snapshot_management
+      multiple_actions_without_snapshot_management + [[_('Create Snapshot'), select_multiple_host_snapshots_path]]
+    end
+  end
+end

--- a/app/views/foreman_snapshot_management/snapshots/select_multiple_host.html.erb
+++ b/app/views/foreman_snapshot_management/snapshots/select_multiple_host.html.erb
@@ -1,0 +1,17 @@
+<%= render 'hosts/selected_hosts', :hosts => @hosts %>
+
+<% if @hosts.empty? %>
+  <%= _('No capable hosts selected') %>
+<% else %>
+  <%= form_for :snapshot, :url => create_multiple_host_snapshots_path(:host_ids => @hosts.map{ | h| h.id}) do |f| %>
+    <%= text_f f, :name,
+      { :label => _("Snapshot")}
+    %>
+    <%= textarea_f f, :description,
+      { :label => _("Description")}
+    %>
+    <%= checkbox_f f, :include_ram,
+      { :label => _("Include RAM")}
+    %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,4 +25,10 @@ Rails.application.routes.draw do
       end
     end
   end
+  resources :snapshots, module: 'foreman_snapshot_management', only: [] do
+    collection do
+      post :select_multiple_host
+      post :create_multiple_host
+    end
+  end
 end

--- a/lib/foreman_snapshot_management/engine.rb
+++ b/lib/foreman_snapshot_management/engine.rb
@@ -6,6 +6,7 @@ module ForemanSnapshotManagement
 
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
+    config.autoload_paths += Dir["#{config.root}/app/helpers/concerns"]
 
     initializer 'foreman_snapshot_management.register_plugin', before: :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_snapshot_management do
@@ -74,6 +75,7 @@ module ForemanSnapshotManagement
       begin
         # Load Foreman extensions
         ::Foreman::Model::Vmware.send(:include, ForemanSnapshotManagement::VmwareExtensions)
+        ::HostsHelper.send(:include, ForemanSnapshotManagement::HostsHelperExtension)
 
         # Load Fog extensions
         if Foreman::Model::Vmware.available?


### PR DESCRIPTION
Same as #25, except for:
* Using `alias_method_chain` instead of `prepend()` to mix into hosts-menu
* flash-error without HTML descriptive-list, because 1.16 does not support HTML in the flash-text