### PR TITLE
Catch RecordInvalid-error when writing audit log

### DIFF
--- a/app/models/foreman_snapshot_management/snapshot.rb
+++ b/app/models/foreman_snapshot_management/snapshot.rb
@@ -162,6 +162,9 @@ module ForemanSnapshotManagement
     rescue Foreman::WrappedException => e
       errors.add(:base, e.wrapped_exception.message)
       false
+    rescue ActiveRecord::RecordInvalid => e
+      errors.add(:base, e.message)
+      false
     end
   end
 end


### PR DESCRIPTION
This should soften the blow of #26 by returning false instead of
crashing.