### PR TITLE
api v2 requests actually work

### DIFF
--- a/app/controllers/api/v2/snapshots_controller.rb
+++ b/app/controllers/api/v2/snapshots_controller.rb
@@ -34,7 +34,7 @@ module Api
 
       def create
         @snapshot = resource_class.new(snapshot_params.to_h.merge(host: @nested_obj).merge(include_ram: params[:include_ram]))
-        process_response @snapshot.save
+        process_response @snapshot.create
       end
 
       api :PUT, '/hosts/:host_id/snapshots/:id', N_('Update a snapshot')

--- a/app/models/foreman_snapshot_management/snapshot.rb
+++ b/app/models/foreman_snapshot_management/snapshot.rb
@@ -159,6 +159,7 @@ module ForemanSnapshotManagement
 
     def handle_snapshot_errors
       yield
+      true
     rescue Foreman::WrappedException => e
       errors.add(:base, e.wrapped_exception.message)
       false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
         resources :hosts, :only => [] do
           constraints(:id => /[^\/]+/) do
             resources :snapshots, except: [:new, :edit] do
-              put :revert, :on => :collection
+              member do
+                put :revert
+              end
             end
           end
         end

--- a/test/controllers/api/v2/snapshots_test.rb
+++ b/test/controllers/api/v2/snapshots_test.rb
@@ -1,8 +1,10 @@
 require 'test_helper'
 
 class Api::V2::SnapshotsControllerTest < ActionController::TestCase
+  let(:tax_location) { Location.find_by_name('Location 1') }
+  let(:tax_organization) { Organization.find_by_name('Organization 1') }
   let(:compute_resource) do
-    cr = FactoryBot.create(:compute_resource, :vmware, :uuid => 'Solutions')
+    cr = FactoryBot.create(:compute_resource, :vmware, :uuid => 'Solutions', :locations => [tax_location], organizations: [tax_organization])
     ComputeResource.find_by_id(cr.id)
   end
   let(:uuid) { '5032c8a5-9c5e-ba7a-3804-832a03e16381' }

--- a/test/controllers/foreman_snapshot_management/snapshots_controller_test.rb
+++ b/test/controllers/foreman_snapshot_management/snapshots_controller_test.rb
@@ -2,8 +2,10 @@ require 'test_helper'
 
 module ForemanSnapshotManagement
   class SnapshotsControllerTest < ActionController::TestCase
+    let(:tax_location) { Location.find_by_name('Location 1') }
+    let(:tax_organization) { Organization.find_by_name('Organization 1') }
     let(:compute_resource) do
-      cr = FactoryBot.create(:compute_resource, :vmware, :uuid => 'Solutions')
+      cr = FactoryBot.create(:compute_resource, :vmware, :uuid => 'Solutions', :locations => [tax_location], organizations: [tax_organization])
       ComputeResource.find_by_id(cr.id)
     end
     let(:uuid) { '5032c8a5-9c5e-ba7a-3804-832a03e16381' }


### PR DESCRIPTION
This fixes a couple of issues we found with the current API implementation.

* A create call may not call `.save` as this requires the snapshot to exist.
* The snapshot models returned false even if everything was ok. This caused `resource have no errors` error.
* The urls generated for the revert call did not match the API doc.
* The test failed on latest develop.

All in all, a bummer.

The calls can be tested with this handy script:

```bash
#!/bin/bash

FOREMAN_URL="http://localhost:3000"
HOST="allan-deschner.example.com"

# Index
curl -k -u admin:test -H "Accept: version=2,application/json" -H "Content-Type: application/json" -X GET ${FOREMAN_URL}/api/hosts/${HOST}/snapshots

# Create
curl -k -u admin:test -H "Accept: version=2,application/json" -H "Content-Type: application/json" -X POST ${FOREMAN_URL}/api/hosts/${HOST}/snapshots -d '
{
  "snapshot":{
    "name":"blubb",
    "description":"abc"
  }
}'

# Update
curl -k -u admin:test -H "Accept: version=2,application/json" -H "Content-Type: application/json" -X PUT ${FOREMAN_URL}/api/hosts/${HOST}/snapshots/snapshot-1428165 -d '
{
  "snapshot":{
    "name":"blubber",
    "description":"abc"
  }
}'

# Delete
curl -k -u admin:test -H "Accept: version=2,application/json" -H "Content-Type: application/json" -X DELETE ${FOREMAN_URL}/api/hosts/${HOST}/snapshots/snapshot-1428165

# Revert
curl -k -u admin:test -H "Accept: version=2,application/json" -H "Content-Type: application/json" -X PUT ${FOREMAN_URL}/api/hosts/${HOST}/snapshots/snapshot-1675005/revert
```