### PR TITLE
support fog-vsphere >= 3.0.0

### DIFF
--- a/app/models/concerns/fog_extensions/vsphere/snapshots/real.rb
+++ b/app/models/concerns/fog_extensions/vsphere/snapshots/real.rb
@@ -7,7 +7,7 @@ module FogExtensions
           raise ArgumentError, 'snapshot is a required parameter' unless options.key? 'snapshot'
           raise ArgumentError, 'removeChildren is a required parameter' unless options.key? 'removeChildren'
 
-          raise ArgumentError, 'snapshot is a required parameter' unless ::Fog::Compute::Vsphere::Snapshot === options['snapshot']
+          raise ArgumentError, 'snapshot is a required parameter' unless ::ForemanSnapshotManagement.fog_vsphere_namespace::Snapshot === options['snapshot']
 
           task = options['snapshot'].mo_ref.RemoveSnapshot_Task(
             removeChildren: options['removeChildren']
@@ -26,7 +26,7 @@ module FogExtensions
           raise ArgumentError, 'name is a required parameter' unless options.key? 'name'
           raise ArgumentError, 'description is a required parameter' unless options.key? 'description'
 
-          raise ArgumentError, 'snapshot is a required parameter' unless ::Fog::Compute::Vsphere::Snapshot === options['snapshot']
+          raise ArgumentError, 'snapshot is a required parameter' unless ::ForemanSnapshotManagement.fog_vsphere_namespace::Snapshot === options['snapshot']
 
           options['snapshot'].mo_ref.RenameSnapshot(
             name: options['name'],

--- a/lib/foreman_snapshot_management/engine.rb
+++ b/lib/foreman_snapshot_management/engine.rb
@@ -79,8 +79,8 @@ module ForemanSnapshotManagement
 
         # Load Fog extensions
         if Foreman::Model::Vmware.available?
-          Fog::Compute::Vsphere::Real.send(:prepend, FogExtensions::Vsphere::Snapshots::Real)
-          Fog::Compute::Vsphere::Mock.send(:prepend, FogExtensions::Vsphere::Snapshots::Mock)
+          ForemanSnapshotManagement.fog_vsphere_namespace::Real.send(:prepend, FogExtensions::Vsphere::Snapshots::Real)
+          ForemanSnapshotManagement.fog_vsphere_namespace::Mock.send(:prepend, FogExtensions::Vsphere::Snapshots::Mock)
         end
       rescue StandardError => e
         Rails.logger.warn "ForemanSnapshotManagement: skipping engine hook (#{e})"
@@ -97,6 +97,19 @@ module ForemanSnapshotManagement
       locale_dir = File.join(File.expand_path('../..', __dir__), 'locale')
       locale_domain = 'foreman_snapshot_management'
       Foreman::Gettext::Support.add_text_domain locale_domain, locale_dir
+    end
+  end
+
+  def self.fog_vsphere_namespace
+    @fog_vsphere_namespace ||= calculate_fog_vsphere_namespace
+  end
+
+  def self.calculate_fog_vsphere_namespace
+    require 'fog/vsphere/version'
+    if Gem::Version.new(Fog::Vsphere::VERSION) >= Gem::Version.new('3.0.0')
+      Fog::Vsphere::Compute
+    else
+      Fog::Compute::Vsphere
     end
   end
 end


### PR DESCRIPTION
`fog-vsphere` 3.0, that will be part of Foreman 1.22, changed the module structure to comply with latest fog recommendations.
This patch dynamically chooses the right constant to apply the extensions so the plugin code is compatible with both fog-vsphere 2.0 and 3.0 branches.