### PR TITLE
Jenkins rubocop test fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ Rails/ActionFilter:
 Metrics/MethodLength:
   Max: 40
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 Style/RedundantSelf:
@@ -23,7 +23,7 @@ Style/RedundantSelf:
 Metrics/ClassLength:
   Max: 500
 
-Style/FileName:
+Naming/FileName:
   Exclude:
       - 'db/seeds.d/*'
 
@@ -60,7 +60,7 @@ Metrics/LineLength:
 Metrics/ModuleLength:
     Max: 400
 
-Style/MethodName:
+Naming/MethodName:
   Exclude:
     - 'app/models/concerns/orchestration/*.rb'
 

--- a/foreman_snapshot_management.gemspec
+++ b/foreman_snapshot_management.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface'
   s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'rubocop', '0.49.1'
+  s.add_development_dependency 'rubocop', '0.54.0'
 end


### PR DESCRIPTION
* Add rake-tasks for rubocop and unit-tests creating junit-xml results for jenkins
* Update required rubocop-version and fix resulting warnings