### PR TITLE
Add missing permissions for multiple snapshots for non-admin

### DIFF
--- a/lib/foreman_snapshot_management/engine.rb
+++ b/lib/foreman_snapshot_management/engine.rb
@@ -22,7 +22,7 @@ module ForemanSnapshotManagement
           }, :resource_type => 'Host'
 
           permission :create_snapshots, {
-            :'foreman_snapshot_management/snapshots' => [:create],
+            :'foreman_snapshot_management/snapshots' => [:create, :select_multiple_host, :create_multiple_host],
             :'api/v2/snapshots' => [:create]
           }, :resource_type => 'Host'
 


### PR DESCRIPTION
This PR adds the missing permission for multiple snapshots (bulk actions).

This results in a 403 for the client and infinite loading popup:
```
2020-01-16T15:42:08 [I|app|] Started POST "/snapshots/select_multiple_host" for <IP> at 2020-01-16 15:42:08 +0100
2020-01-16T15:42:08 [I|app|ceace] Processing by ForemanSnapshotManagement::SnapshotsController#select_multiple_host as HTML
2020-01-16T15:42:08 [I|app|ceace]   Parameters: {"host_ids"=>["30780", "30966"]}
2020-01-16T15:42:08 [I|app|ceace] Current user set to <User> (regular)
2020-01-16T15:42:09 [I|per|ceace] rendering 403 because of missing permission
2020-01-16T15:42:09 [I|app|ceace]   Rendering common/403.html.erb
2020-01-16T15:42:09 [I|app|ceace]   Rendered common/403.html.erb (21.8ms)
2020-01-16T15:42:09 [I|app|ceace] Filter chain halted as :authorize rendered or redirected
```