### PR TITLE
Fix API permissions

### DIFF
--- a/test/controllers/api/v2/snapshots_test.rb
+++ b/test/controllers/api/v2/snapshots_test.rb
@@ -13,137 +13,260 @@ class Api::V2::SnapshotsControllerTest < ActionController::TestCase
   let(:host) { FactoryBot.create(:host, :managed, :compute_resource => compute_resource, :uuid => uuid) }
   let(:snapshot_id) { 'snapshot-0101' }
   let(:proxmox_compute_resource) do
-    FactoryBot.create(:proxmox_cr)
-    ComputeResource.find_by(type: 'ForemanFogProxmox::Proxmox')
+    cr = FactoryBot.create(:proxmox_cr)
+    ComputeResource.find_by(id: cr.id)
   end
   let(:vmid) { '100' }
   let(:proxmox_host) { FactoryBot.create(:host, :managed, :compute_resource => proxmox_compute_resource, :uuid => vmid) }
   let(:proxmox_snapshot) { 'snapshot1' }
+  let(:manager_user) {
+    roles = [Role.find_by_name('Snapshot Manager')]
+    FactoryBot.create(:user, :organizations => [tax_organization], :locations => [tax_location], :roles => roles)
+  }
+  let(:view_user) {
+    roles = [Role.find_by_name('Snapshot Viewer')]
+    FactoryBot.create(:user, :organizations => [tax_organization], :locations => [tax_location], :roles => roles)
+  }
   setup { ::Fog.mock! }
   teardown { ::Fog.unmock! }
 
-  test 'should get index of Vmware Snapshots' do
-    get :index, params: { :host_id => host.to_param }
-    assert_response :success
-    assert_not_nil assigns(:snapshots)
-    body = ActiveSupport::JSON.decode(@response.body)
-    assert_not_empty body
-    assert_not_empty body['results']
+  context 'view user' do
+    setup do
+      # Make sure that test-hosts are created here (by the admin-user)
+      host
+      proxmox_host
+      @orig_user = User.current
+      User.current = view_user
+    end
+    teardown do
+      User.current = @orig_user
+    end
+
+    test 'should get index of Vmware Snapshots' do
+        get :index, params: { :host_id => host.to_param }
+      assert_response :success
+      assert_not_nil assigns(:snapshots)
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+      assert_not_empty body['results']
+    end
+
+    test 'should get index of Proxmox Snapshots' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+        get :index, params: { :host_id => proxmox_host.to_param }
+      assert_response :success
+      assert_not_nil assigns(:snapshots)
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+      assert_not_empty body['results']
+    end
+
+    test 'should search VMware snapshot' do
+      get :index, params: { :host_id => host.to_param, :search => 'name= clean' }
+      assert_response :success
+      assert_not_nil assigns(:snapshots)
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+      assert_not_empty body['results']
+      assert body['results'].count == 1
+    end
+
+    test 'should search Proxmox snapshot' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      get :index, params: { :host_id => proxmox_host.to_param, :search => 'name= snapshot1' }
+      assert_response :success
+      assert_not_nil assigns(:snapshots)
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+      assert_not_empty body['results']
+      assert body['results'].count == 1
+    end
+
+    test 'should refute search Vmware snapshot' do
+      get :index, params: { :host_id => host.to_param, :search => 'name != clean' }
+      assert_response :internal_server_error
+    end
+
+    test 'should show Vmware snapshot' do
+      get :show, params: { :host_id => host.to_param, :id => snapshot_id }
+      assert_not_nil assigns(:snapshot)
+      assert_response :success
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+    end
+
+    test 'should show Proxmox snapshot' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      get :show, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot }
+      assert_not_nil assigns(:snapshot)
+      assert_response :success
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+    end
+
+    test 'should 404 for unknown Vmware snapshot' do
+      get :show, params: { :host_id => host.to_param, :id => 'does-not-exist' }
+      assert_response :not_found
+    end
+
+    test 'should refute create Vmware snapshot' do
+      post :create, params: { :host_id => host.to_param, :name => 'test' }
+      assert_response :forbidden
+    end
+
+    test 'should refute update Vmware snapshot' do
+      name = 'test'
+      put :update, params: { :host_id => host.to_param, :id => snapshot_id.to_param, :name => name.to_param }
+      assert_response :forbidden
+    end
+
+    test 'should refute destroy Vmware snapshot' do
+      delete :destroy, params: { :host_id => host.to_param, :id => snapshot_id.to_param }
+      assert_response :forbidden
+    end
+
+    test 'should refute revert Proxmox snapshot' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      put :revert, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot.to_param }
+      assert_response :forbidden
+    end
   end
 
-  test 'should get index of Proxmox Snapshots' do
-    Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
-    get :index, params: { :host_id => proxmox_host.to_param }
-    assert_response :success
-    assert_not_nil assigns(:snapshots)
-    body = ActiveSupport::JSON.decode(@response.body)
-    assert_not_empty body
-    assert_not_empty body['results']
-  end
+  context 'manager user' do
+    setup do
+      # Make sure that test-hosts are created here (by the admin-user)
+      host
+      proxmox_host
+      @orig_user = User.current
+      User.current = manager_user
+    end
+    teardown do
+      User.current = @orig_user
+    end
 
-  test 'should search VMware snapshot' do
-    get :index, params: { :host_id => host.to_param, :search => 'name= clean' }
-    assert_response :success
-    assert_not_nil assigns(:snapshots)
-    body = ActiveSupport::JSON.decode(@response.body)
-    assert_not_empty body
-    assert_not_empty body['results']
-    assert body['results'].count == 1
-  end
+    test 'should get index of Vmware Snapshots' do
+      get :index, params: { :host_id => host.to_param }
+      assert_response :success
+      assert_not_nil assigns(:snapshots)
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+      assert_not_empty body['results']
+    end
 
-  test 'should search Proxmox snapshot' do
-    Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
-    get :index, params: { :host_id => proxmox_host.to_param, :search => 'name= snapshot1' }
-    assert_response :success
-    assert_not_nil assigns(:snapshots)
-    body = ActiveSupport::JSON.decode(@response.body)
-    assert_not_empty body
-    assert_not_empty body['results']
-    assert body['results'].count == 1
-  end
+    test 'should get index of Proxmox Snapshots' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      get :index, params: { :host_id => proxmox_host.to_param }
+      assert_response :success
+      assert_not_nil assigns(:snapshots)
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+      assert_not_empty body['results']
+    end
 
-  test 'should refute search Vmware snapshot' do
-    get :index, params: { :host_id => host.to_param, :search => 'name != clean' }
-    assert_response :internal_server_error
-  end
+    test 'should search VMware snapshot' do
+      get :index, params: { :host_id => host.to_param, :search => 'name= clean' }
+      assert_response :success
+      assert_not_nil assigns(:snapshots)
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+      assert_not_empty body['results']
+      assert body['results'].count == 1
+    end
 
-  test 'should show Vmware snapshot' do
-    get :show, params: { :host_id => host.to_param, :id => snapshot_id }
-    assert_not_nil assigns(:snapshot)
-    assert_response :success
-    body = ActiveSupport::JSON.decode(@response.body)
-    assert_not_empty body
-  end
+    test 'should search Proxmox snapshot' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      get :index, params: { :host_id => proxmox_host.to_param, :search => 'name= snapshot1' }
+      assert_response :success
+      assert_not_nil assigns(:snapshots)
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+      assert_not_empty body['results']
+      assert body['results'].count == 1
+    end
 
-  test 'should show Proxmox snapshot' do
-    Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
-    get :show, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot }
-    assert_not_nil assigns(:snapshot)
-    assert_response :success
-    body = ActiveSupport::JSON.decode(@response.body)
-    assert_not_empty body
-  end
+    test 'should refute search Vmware snapshot' do
+      get :index, params: { :host_id => host.to_param, :search => 'name != clean' }
+      assert_response :internal_server_error
+    end
 
-  test 'should 404 for unknown Vmware snapshot' do
-    get :show, params: { :host_id => host.to_param, :id => 'does-not-exist' }
-    assert_response :not_found
-  end
+    test 'should show Vmware snapshot' do
+      get :show, params: { :host_id => host.to_param, :id => snapshot_id }
+      assert_not_nil assigns(:snapshot)
+      assert_response :success
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+    end
 
-  test 'should create Vmware snapshot' do
-    post :create, params: { :host_id => host.to_param, :name => 'test' }
-    assert_response :created
-    assert_not_nil assigns(:snapshot)
-  end
+    test 'should show Proxmox snapshot' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      get :show, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot }
+      assert_not_nil assigns(:snapshot)
+      assert_response :success
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_empty body
+    end
 
-  test 'should create Proxmox snapshot' do
-    Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
-    post :create, params: { :host_id => proxmox_host.to_param, :name => 'test' }
-    assert_response :created
-    assert_not_nil assigns(:snapshot)
-  end
+    test 'should 404 for unknown Vmware snapshot' do
+      get :show, params: { :host_id => host.to_param, :id => 'does-not-exist' }
+      assert_response :not_found
+    end
 
-  test 'should update Vmware snapshot' do
-    name = 'test'
-    put :update, params: { :host_id => host.to_param, :id => snapshot_id.to_param, :name => name.to_param }
-    assert_response :success
-  end
+    test 'should create Vmware snapshot' do
+      post :create, params: { :host_id => host.to_param, :name => 'test' }
+      assert_response :created
+      assert_not_nil assigns(:snapshot)
+    end
 
-  test 'should update Proxmox snapshot' do
-    Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
-    description = 'snapshot1 updated'
-    put :update, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot.to_param, :description => description.to_param }
-    assert_response :success
-  end
+    test 'should create Proxmox snapshot' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      post :create, params: { :host_id => proxmox_host.to_param, :name => 'test' }
+      assert_response :created
+      assert_not_nil assigns(:snapshot)
+    end
 
-  test 'should refute update Proxmox snapshot name' do
-    Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
-    name = 'test'
-    put :update, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot.to_param, :name => name.to_param }
-    assert_response :unprocessable_entity
-  end
+    test 'should update Vmware snapshot' do
+      name = 'test'
+      put :update, params: { :host_id => host.to_param, :id => snapshot_id.to_param, :name => name.to_param }
+      assert_response :success
+    end
 
-  test 'should destroy Vmware snapshot' do
-    delete :destroy, params: { :host_id => host.to_param, :id => snapshot_id.to_param }
-    assert_response :success
-  end
+    test 'should update Proxmox snapshot' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      description = 'snapshot1 updated'
+      put :update, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot.to_param, :description => description.to_param }
+      assert_response :success
+    end
 
-  test 'should destroy Proxmox snapshot' do
-    Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
-    delete :destroy, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot.to_param }
-    assert_response :success
-    body = ActiveSupport::JSON.decode(@response.body)
-    assert_not_nil body['name']
-    assert_nil body['id']
-  end
+    test 'should refute update Proxmox snapshot name' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      name = 'test'
+      put :update, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot.to_param, :name => name.to_param }
+      assert_response :unprocessable_entity
+    end
 
-  test 'should revert Vmware snapshot' do
-    put :revert, params: { :host_id => host.to_param, :id => snapshot_id.to_param }
-    assert_response :success
-  end
+    test 'should destroy Vmware snapshot' do
+      delete :destroy, params: { :host_id => host.to_param, :id => snapshot_id.to_param }
+      assert_response :success
+    end
 
-  test 'should revert Proxmox snapshot' do
-    Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
-    put :revert, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot.to_param }
-    assert_response :success
+    test 'should destroy Proxmox snapshot' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      delete :destroy, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot.to_param }
+      assert_response :success
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_not_nil body['name']
+      assert_nil body['id']
+    end
+
+    test 'should revert Vmware snapshot' do
+      put :revert, params: { :host_id => host.to_param, :id => snapshot_id.to_param }
+      assert_response :success
+    end
+
+    test 'should revert Proxmox snapshot' do
+      Host::Managed.any_instance.stubs(:vm_exists?).returns(false)
+      put :revert, params: { :host_id => proxmox_host.to_param, :id => proxmox_snapshot.to_param }
+      assert_response :success
+    end
   end
 end

--- a/test/factories/proxmox_factory.rb
+++ b/test/factories/proxmox_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :proxmox_resource, :class => ComputeResource do
-    sequence(:name) { |n| "compute_resource#{n}" }
+    sequence(:name) { |n| "compute_resource_proxmox#{n}" }
     organizations { [Organization.find_by(name: 'Organization 1')] }
     locations { [Location.find_by(name: 'Location 1')] }
 


### PR DESCRIPTION
Unfortunately, the `find_required_nested_object` before_action automatically pulls in the `edit_host`-permission, which should not be needed if you only edit the Snapshots of a host.

Fixes #61