### PR TITLE
Don't show Rubocop not loaded warning

### DIFF
--- a/lib/tasks/foreman_snapshot_management_tasks.rake
+++ b/lib/tasks/foreman_snapshot_management_tasks.rake
@@ -37,7 +37,7 @@ begin
     end
   end
 rescue LoadError
-  puts 'Rubocop not loaded.'
+  # 'Rubocop not loaded.'
 end
 
 namespace :jenkins do


### PR DESCRIPTION
This error is shown at runtime to users using foreman-rake. Prior to 9d9a8357c428a60cb3052016620218635b58a9a3 it was only attempting to load RuboCop when invoking the task.

Fixes: 9d9a8357c428 ("Add separate jenkins-test jobs")