### PR TITLE
Replace ForemanModal component with PF5 Modal and fix 'no-magic-numbers'

### DIFF
--- a/webpack/components/SnapshotManagement/components/SnapshotForm/SnapshotForm.js
+++ b/webpack/components/SnapshotManagement/components/SnapshotForm/SnapshotForm.js
@@ -24,6 +24,9 @@ import {
 
 import './snapshotForm.scss';
 
+const MAX_SNAPSHOT_NAME_LENGTH = 80;
+const LIMITED_MAX_SNAPSHOT_NAME_LENGTH = 40;
+
 const SnapshotForm = ({
   initialValues,
   capabilities,
@@ -34,7 +37,7 @@ const SnapshotForm = ({
   host,
   selectAllMode,
 }) => {
-  let nameValidation = Yup.string().max(80, 'Too Long!');
+  let nameValidation = Yup.string().max(MAX_SNAPSHOT_NAME_LENGTH, 'Too Long!');
   if (capabilities.limitSnapshotNameFormat)
     nameValidation = nameValidation
       .min(2, 'Too Short!')
@@ -44,7 +47,7 @@ const SnapshotForm = ({
           'Name must contain at least 2 characters starting with alphabet. Valid characters are A-Z a-z 0-9 _'
         )
       )
-      .max(40, 'Too Long!');
+      .max(LIMITED_MAX_SNAPSHOT_NAME_LENGTH, 'Too Long!');
 
   const validationSchema = Yup.object().shape({
     name: nameValidation.required('is required'),

--- a/webpack/components/SnapshotManagement/components/SnapshotForm/SnapshotForm.js
+++ b/webpack/components/SnapshotManagement/components/SnapshotForm/SnapshotForm.js
@@ -5,7 +5,6 @@ import { Formik } from 'formik';
 
 import { translate as __ } from 'foremanReact/common/I18n';
 import TextField from 'foremanReact/components/common/forms/TextField';
-import { FieldLevelHelp } from 'patternfly-react';
 
 import {
   Form as PfForm,
@@ -13,6 +12,7 @@ import {
   Button,
   Card,
   CardBody,
+  FormGroup,
   Select,
   SelectList,
   SelectOption,
@@ -161,22 +161,19 @@ const SnapshotForm = ({
                 inputClassName="pf-v5-u-w-90"
               />
 
-              <div>
-                <label className="pf-v5-c-form__label">
-                  <span className="pf-v5-c-form__label-text">
-                    {__('Snapshot Mode')}
-                  </span>
-                  <FieldLevelHelp
-                    buttonClass="field-help"
-                    placement="top"
-                    content={__(
-                      "Select Snapshot Mode between 'Disk only' (default) or mutually exclusive options, 'Memory' (includes RAM) and 'Quiesce'."
-                    )}
-                  />
-                </label>
-
+              <FormGroup
+                label={__('Snapshot Mode')}
+                fieldId="snapshot-mode-select"
+                labelHelp={{
+                  content: __(
+                    "Select Snapshot Mode between 'Disk only' (default) or mutually exclusive options, 'Memory' (includes RAM) and 'Quiesce'."
+                  ),
+                  'aria-label': __('Snapshot mode help'),
+                }}
+              >
                 <div className="pf-v5-u-mt-sm">
                   <Select
+                    id="snapshot-mode-select"
                     isOpen={isSelectOpen}
                     selected={snapshotMode || undefined}
                     onOpenChange={setIsSelectOpen}
@@ -190,8 +187,7 @@ const SnapshotForm = ({
                         ref={toggleRef}
                         onClick={() => setIsSelectOpen(prev => !prev)}
                         isExpanded={isSelectOpen}
-                        isFullWidth
-                        className="pf-v5-c-form-control"
+                        style={{ width: '100%' }}
                         aria-label={__('Snapshot mode')}
                         ouiaId="snapshot-mode-toggle"
                       >
@@ -234,7 +230,7 @@ const SnapshotForm = ({
                     </HelperText>
                   )}
                 </div>
-              </div>
+              </FormGroup>
 
               {status && (
                 <HelperText isLiveRegion className="pf-v5-u-mt-sm">

--- a/webpack/components/SnapshotManagement/components/SnapshotFormModal/SnapshotFormModal.js
+++ b/webpack/components/SnapshotManagement/components/SnapshotFormModal/SnapshotFormModal.js
@@ -1,12 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Title, Text, TextContent } from '@patternfly/react-core';
-import ForemanModal from 'foremanReact/components/ForemanModal';
+import {
+  Modal,
+  ModalVariant,
+  Title,
+  Text,
+  TextContent,
+} from '@patternfly/react-core';
 import { translate as __, sprintf } from 'foremanReact/common/I18n';
 import SnapshotForm from '../SnapshotForm';
 import { SNAPSHOT_FORM_MODAL } from './SnapshotFormModalConstants';
 
 const SnapshotFormModal = ({
+  isOpen,
   selectedHosts,
   selectedHostsCount,
   setModalClosed,
@@ -16,36 +22,39 @@ const SnapshotFormModal = ({
 }) => {
   const displayCount = selectedHostsCount === 0 ? 1 : selectedHostsCount;
   const hasSelection = selectedHostsCount > 0 || host;
+  const header = (
+    <TextContent className="pf-v5-u-mb-md">
+      <Title headingLevel="h1" size="3xl" ouiaId="snapshot-modal-title">
+        {__('Create snapshot')}
+      </Title>
+
+      {hasSelection && (
+        <Text
+          component="small"
+          className="pf-v5-u-color-200 pf-v5-u-font-size-sm pf-v5-u-mt-sm"
+          ouiaId="snapshot-modal-hosts-count"
+        >
+          {sprintf(
+            displayCount === 1
+              ? __('%s host is selected for snapshot creation')
+              : __('%s hosts are selected for snapshot creation'),
+            displayCount
+          )}
+        </Text>
+      )}
+    </TextContent>
+  );
 
   return (
-    <ForemanModal
+    <Modal
       id={SNAPSHOT_FORM_MODAL}
-      enforceFocus
+      variant={ModalVariant.medium}
+      isOpen={isOpen}
+      onClose={setModalClosed}
+      onEscapePress={setModalClosed}
+      header={header}
       ouiaId="snapshot-form-modal"
     >
-      <ForemanModal.Header closeButton={false}>
-        <TextContent className="pf-v5-u-mb-md">
-          <Title headingLevel="h1" size="3xl" ouiaId="snapshot-modal-title">
-            {__('Create snapshot')}
-          </Title>
-
-          {hasSelection && (
-            <Text
-              component="small"
-              className="pf-v5-u-color-200 pf-v5-u-font-size-sm pf-v5-u-mt-sm"
-              ouiaId="snapshot-modal-hosts-count"
-            >
-              {sprintf(
-                displayCount === 1
-                  ? __('%s host is selected for snapshot creation')
-                  : __('%s hosts are selected for snapshot creation'),
-                displayCount
-              )}
-            </Text>
-          )}
-        </TextContent>
-      </ForemanModal.Header>
-
       {hasSelection && (
         <SnapshotForm
           setModalClosed={setModalClosed}
@@ -55,11 +64,12 @@ const SnapshotFormModal = ({
           {...props}
         />
       )}
-    </ForemanModal>
+    </Modal>
   );
 };
 
 SnapshotFormModal.propTypes = {
+  isOpen: PropTypes.bool,
   selectedHosts: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number.isRequired,
@@ -82,6 +92,7 @@ SnapshotFormModal.propTypes = {
 };
 
 SnapshotFormModal.defaultProps = {
+  isOpen: false,
   selectedHosts: [],
   selectedHostsCount: 0,
   host: null,

--- a/webpack/components/SnapshotManagement/components/SnapshotFormModal/__tests__/SnapshotFormModal.test.js
+++ b/webpack/components/SnapshotManagement/components/SnapshotFormModal/__tests__/SnapshotFormModal.test.js
@@ -12,6 +12,7 @@ const setModalClosed = () => null;
 const fetchBulkParams = () => null;
 const fixtures = {
   normal: {
+    isOpen: true,
     host: { id: 42, name: 'deep.thought' },
     setModalClosed,
     fetchBulkParams,

--- a/webpack/components/SnapshotManagement/components/SnapshotFormModal/__tests__/__snapshots__/SnapshotFormModal.test.js.snap
+++ b/webpack/components/SnapshotManagement/components/SnapshotFormModal/__tests__/__snapshots__/SnapshotFormModal.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SnapshotFormModal renders normal 1`] = `
-<ConnectedForemanModal
-  enforceFocus={true}
-  id="foremanSnapshotMgmtSnapshotFormModal"
-  ouiaId="snapshot-form-modal"
-  title=""
->
-  <ForemanModalHeader
-    closeButton={false}
-  >
+<Modal
+  actions={Array []}
+  appendTo={[Function]}
+  aria-describedby=""
+  aria-label=""
+  aria-labelledby=""
+  className=""
+  hasNoBodyWrapper={false}
+  header={
     <TextContent
       className="pf-v5-u-mb-md"
     >
@@ -28,7 +28,20 @@ exports[`SnapshotFormModal renders normal 1`] = `
         1 host is selected for snapshot creation
       </Text>
     </TextContent>
-  </ForemanModalHeader>
+  }
+  id="foremanSnapshotMgmtSnapshotFormModal"
+  isOpen={true}
+  onClose={[Function]}
+  onEscapePress={[Function]}
+  ouiaId="snapshot-form-modal"
+  ouiaSafe={true}
+  position="default"
+  showClose={true}
+  title=""
+  titleIconVariant={null}
+  titleLabel=""
+  variant="medium"
+>
   <WrappedSnapshotForm
     fetchBulkParams={[Function]}
     host={
@@ -40,5 +53,5 @@ exports[`SnapshotFormModal renders normal 1`] = `
     selectedHosts={Array []}
     setModalClosed={[Function]}
   />
-</ConnectedForemanModal>
+</Modal>
 `;

--- a/webpack/components/SnapshotManagement/components/SnapshotFormModal/index.js
+++ b/webpack/components/SnapshotManagement/components/SnapshotFormModal/index.js
@@ -3,9 +3,15 @@ import useSnapshotFormModal from './useSnapshotFormModal';
 import SnapshotFormModal from './SnapshotFormModal';
 
 const WrappedSnapshotFormModal = props => {
-  const { setModalClosed } = useSnapshotFormModal();
+  const { isOpen, setModalClosed } = useSnapshotFormModal();
 
-  return <SnapshotFormModal setModalClosed={setModalClosed} {...props} />;
+  return (
+    <SnapshotFormModal
+      isOpen={isOpen}
+      setModalClosed={setModalClosed}
+      {...props}
+    />
+  );
 };
 
 export default WrappedSnapshotFormModal;

--- a/webpack/components/SnapshotManagement/components/SnapshotFormModal/useSnapshotFormModal.js
+++ b/webpack/components/SnapshotManagement/components/SnapshotFormModal/useSnapshotFormModal.js
@@ -1,7 +1,16 @@
-import { useForemanModal } from 'foremanReact/components/ForemanModal/ForemanModalHooks';
+import { useBulkModalOpen } from 'foremanReact/common/BulkModalStateHelper';
 
 import { SNAPSHOT_FORM_MODAL } from './SnapshotFormModalConstants';
 
-const useSnapshotFormModal = () => useForemanModal({ id: SNAPSHOT_FORM_MODAL });
+const useSnapshotFormModal = () => {
+  const { isOpen, open, close, toggle } = useBulkModalOpen(SNAPSHOT_FORM_MODAL);
+
+  return {
+    isOpen,
+    setModalOpen: open,
+    setModalClosed: close,
+    toggleModal: toggle,
+  };
+};
 
 export default useSnapshotFormModal;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -9,6 +9,9 @@ import SnapshotManagementCard from './components/SnapshotManagementCard';
 import BulkCreateSnapshotMenuItem from './components/SnapshotManagement/components/BulkActions/BulkCreateSnapshotMenuItem/BulkCreateSnapshotMenuItem';
 import BulkSnapshotModalScene from './components/SnapshotManagement/components/BulkActions/BulkSnapshotModalScene/BulkSnapshotModalScene';
 
+const CARD_FILL_PRIORITY = 1000;
+const BULK_ACTION_FILL_PRIORITY = 500;
+
 // register reducers
 Object.entries(reducers).forEach(([key, reducer]) =>
   registerReducer(key, reducer)
@@ -19,19 +22,19 @@ addGlobalFill(
   'host-overview-cards',
   'foreman_snapshot_management-card',
   <SnapshotManagementCard key="foreman_snapshot_management-card" />,
-  1000
+  CARD_FILL_PRIORITY
 );
 
 addGlobalFill(
   '_all-hosts-modals',
   'foreman_snapshot_management-bulk-modal',
   <BulkSnapshotModalScene key="foreman_snapshot_management-bulk-modal" />,
-  500
+  BULK_ACTION_FILL_PRIORITY
 );
 
 addGlobalFill(
   'hosts-index-kebab',
   'foreman_snapshot_management-bulk-create',
   <BulkCreateSnapshotMenuItem key="foreman_snapshot_management-bulk-create" />,
-  500
+  BULK_ACTION_FILL_PRIORITY
 );

--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -1,6 +1,8 @@
 // runs before each test to make sure console.error output will
 // fail a test (i.e. default PropType missing). Check the error
 // output and traceback for actual error.
+const JEST_TIMEOUT_MS = 10000;
+
 global.console.error = (error, stack) => {
   /* eslint-disable-next-line no-console */
   if (stack) console.log(stack); // Prints out original stack trace
@@ -8,4 +10,4 @@ global.console.error = (error, stack) => {
 };
 
 // Increase jest timeout as some tests using multiple http mocks can time out on CI systems.
-jest.setTimeout(10000);
+jest.setTimeout(JEST_TIMEOUT_MS);


### PR DESCRIPTION
ForemanModal has been deprecated in Foreman core and will be removed in version 5.0.0: theforeman/foreman#10852

To keep this plugin compatible, we also need to replace our usage of ForemanModal with PF5 components.

Co-Authored-By: OpenAI Codex